### PR TITLE
Load a folder of views

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ class FooList(ListView):
     model = Foo
 ```
 
+### Parameters
+
+* `paths`: is in a plural form because support also a list of paths
+* `name` the classic route name
+* `namespace`: {I don't know what to write here}
+* `extra_modules`: can be a real path or the python module itselfs (require a list)
+* `login_required`: so you can avoid the Django decorator
+* `permission_required`: so you can avoid the Django decorator
+
+### entra_modules example for real paths
+
+```
+import os
+# We need the project directory
+root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+urlpatterns = [
+    path("", include_view_urls(extra_modules=[root + "/portal/views"])),
+]
+```
+
 ## Development
 
 ```console

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ class FooList(ListView):
 * `paths`: is in a plural form because support also a list of paths
 * `name` the classic route name
 * `namespace`: {I don't know what to write here}
-* `extra_modules`: can be a real path or the python module itselfs (require a list)
+* `extra_modules`: the python module itselfs (require a list)
+* `extra_packages`: can be a real path (require a list)
 * `login_required`: so you can avoid the Django decorator
 * `permission_required`: so you can avoid the Django decorator
 
-### entra_modules example for real paths
+### extra_packages example for real paths
 
 ```
 import os

--- a/django_view_decorator/urls_utils.py
+++ b/django_view_decorator/urls_utils.py
@@ -1,6 +1,6 @@
-from collections.abc import Sequence
 import importlib
 import os
+from collections.abc import Sequence
 
 from django.urls import include
 from django.urls import URLPattern
@@ -20,11 +20,17 @@ def include_view_urls(
     """
     if extra_modules:
         for module in extra_modules:
-            if module[0] == '/':
-                module_files = [f[:-3] for f in os.listdir(module) if f.endswith(".py") and f != "__init__.py"]
+            if module[0] == "/":
+                module_files = [
+                    f[:-3]
+                    for f in os.listdir(module)
+                    if f.endswith(".py") and f != "__init__.py"
+                ]
 
                 for module_name in module_files:
-                    spec = importlib.util.spec_from_file_location(module_name, os.path.join(module, f"{module_name}.py"))
+                    spec = importlib.util.spec_from_file_location(
+                        module_name, os.path.join(module, f"{module_name}.py")
+                    )
                     _module = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(_module)
             else:

--- a/django_view_decorator/urls_utils.py
+++ b/django_view_decorator/urls_utils.py
@@ -29,7 +29,8 @@ def include_view_urls(
 
                 for module_name in module_files:
                     spec = importlib.util.spec_from_file_location(
-                        module_name, os.path.join(module, f"{module_name}.py")
+                        module_name,
+                        os.path.join(module, f"{module_name}.py"),
                     )
                     _module = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(_module)

--- a/django_view_decorator/urls_utils.py
+++ b/django_view_decorator/urls_utils.py
@@ -10,31 +10,34 @@ from django.urls import URLResolver
 def include_view_urls(
     *,
     extra_modules: list[str] | None = None,
+    extra_packages: list[str] | None = None,
 ) -> tuple[Sequence[URLResolver | URLPattern], str | None, str | None]:
     """
     Include the view urls from the registry discovered by django_view_decorator, and
     optionally from the given modules.
     :param extra_modules: A list of modules to import before including the view urls.
+    :param extra_packages: A list of packages to import before including the view urls.
     :return: A tuple of (urlpatterns, app_name, namespace) (result from calling
         include())
     """
     if extra_modules:
         for module in extra_modules:
-            if module[0] == "/":
-                module_files = [
+            importlib.import_module(f"{module}")
+
+    if extra_packages:
+        for package in extra_packages:
+            if package[0] == "/":
+                package_files = [
                     f[:-3]
-                    for f in os.listdir(module)
+                    for f in os.listdir(package)
                     if f.endswith(".py") and f != "__init__.py"
                 ]
 
-                for module_name in module_files:
+                for package_name in package_files:
                     spec = importlib.util.spec_from_file_location(
-                        module_name,
-                        os.path.join(module, f"{module_name}.py"),
+                        package_name,
+                        os.path.join(package, f"{package_name}.py"),
                     )
-                    _module = importlib.util.module_from_spec(spec)
-                    spec.loader.exec_module(_module)
-            else:
-                importlib.import_module(f"{module}")
+                    spec.loader.exec_module(importlib.util.module_from_spec(spec))
 
     return include("django_view_decorator.urls")

--- a/django_view_decorator/urls_utils.py
+++ b/django_view_decorator/urls_utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from importlib import import_module
+import importlib
+import os
 
 from django.urls import include
 from django.urls import URLPattern
@@ -19,6 +20,14 @@ def include_view_urls(
     """
     if extra_modules:
         for module in extra_modules:
-            import_module(f"{module}")
+            if module[0] == '/':
+                module_files = [f[:-3] for f in os.listdir(module) if f.endswith(".py") and f != "__init__.py"]
+
+                for module_name in module_files:
+                    spec = importlib.util.spec_from_file_location(module_name, os.path.join(module, f"{module_name}.py"))
+                    _module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(_module)
+            else:
+                importlib.import_module(f"{module}")
 
     return include("django_view_decorator.urls")


### PR DESCRIPTION
This fix https://github.com/valberg/django-view-decorator/issues/13

In urls.py it is required that code:

```
import os
root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
urlpatterns = [
path("", include_view_urls(extra_modules=[root + "/portal/views"])),
]
```

In this way loads from a folder the various views automatically.
I will update the readme tomorrow (also some parameters like login_required are not documented, I will do that).